### PR TITLE
fix playground request

### DIFF
--- a/src/plugins/apollo-server/ApolloServerLoaderPlugin.ts
+++ b/src/plugins/apollo-server/ApolloServerLoaderPlugin.ts
@@ -20,7 +20,9 @@ const ApolloServerLoaderPlugin = (option?: ApolloServerLoaderPluginOption) =>
         });
       },
       willSendResponse(requestContext) {
-        Container.reset(requestContext.context._tgdContext.requestId);
+        if (requestContext.context._tgdContext != null) {
+          Container.reset(requestContext.context._tgdContext.requestId);
+        }
       },
     }),
   } as ApolloServerPlugin);


### PR DESCRIPTION
accessing the playground with the browser caused an internal server error with "Cannot read property 'requestId' of undefined". Looks like the "didResolveSource" is not called when the schema is fetched.