### PR TITLE
Add a way to filter dataloader query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { ApolloServerLoaderPlugin } from "./plugins/apollo-server/ApolloServerLoaderPlugin";
-export { TypeormLoader } from "./decorators/typeorm/TypeormLoader";
+export { TypeormLoader, FilteredTypeormLoader } from "./decorators/typeorm/TypeormLoader";
 export { Loader } from "./decorators/Loader";


### PR DESCRIPTION
Hi,
I've added a new decorator  called`FilteredTypeormLoader` which works exactly as `TypeormLoader`  but it applies a custom function to the query builder.

I've implemented this functionality in order to apply some authorization filters on the query created by the TypeormLoader.

### Example
```
@Entity()
@ObjectType()
export class User extends BaseEntity {
  @PrimaryGeneratedColumn()
  @Field()
  id: number;

  @ManyToMany(() => Customer, (customer) => customer.users)
  @JoinTable()
  @Field((_type) => [Customer])
  @FilteredTypeormLoader((qb, context) => {
    if (!context.currentUser.isAdmin) {
      qb.andWhere(...)
    }
  })
  customers: Promise<Customer[]>;

  ...
}
```

I can add some tests and an usage example if you want to include this functionality to the package, otherwise feel free to close the PR.