### PR TITLE
feat: allow to use master replica if the parent operation is mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,23 @@ export default class UserResolver {
   }
 }
 ```
+
+### Automatically use specific replica for mutation operation
+
+When using database with replica and fetching data after performing data mutation, sometimes the loader returns stale data because the typeorm data fetching uses `slave` replica. To overcome this, we need to setup `mutationReplica` to use when fetching data after performing mutation.
+
+```ts
+...
+
+const apollo = new ApolloServer({
+  schema,
+  plugins: [
+    ApolloServerLoaderPlugin({
+      typeormGetConnection: getConnection,  // for use with TypeORM
+      mutationReplica: 'master'
+    }),
+  ],
+});
+
+...
+```

--- a/src/plugins/apollo-server/ApolloServerLoaderPlugin.ts
+++ b/src/plugins/apollo-server/ApolloServerLoaderPlugin.ts
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 
 interface ApolloServerLoaderPluginOption {
   typeormGetConnection?: () => Connection;
+  mutationReplica?: boolean;
 }
 
 const ApolloServerLoaderPlugin = (
@@ -18,6 +19,7 @@ const ApolloServerLoaderPlugin = (
         _tgdContext: {
           requestId: uuidv4(),
           typeormGetConnection: option?.typeormGetConnection,
+          mutationReplica: option?.mutationReplica,
         } as TgdContext,
       });
     },

--- a/src/types/TgdContext.ts
+++ b/src/types/TgdContext.ts
@@ -1,6 +1,7 @@
-import type { Connection } from "typeorm";
+import type { Connection, ReplicationMode } from "typeorm";
 
 export interface TgdContext {
   requestId: string;
   typeormGetConnection?: () => Connection;
+  mutationReplica?: ReplicationMode;
 }


### PR DESCRIPTION
When using database with replica and fetching data after performing data mutation, sometimes the loader returns stale data because the typeorm data fetching uses `slave` replica. To overcome this, we need to setup `mutationReplica` to use when fetching data after performing mutation.